### PR TITLE
Feature upload coverage even if it's under 100%

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,8 +39,12 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Pytest with Coverage
       run: |
-        pytest -v --cov=. --cov-report=term-missing --cov-fail-under=100
+        pytest -v --cov=. --cov-report=term-missing --cov-branch
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Check if coverage under 100
+      run: |
+        coverage report --fail-under=100
+


### PR DESCRIPTION
* split pytest in two steps (running tests with collecting coverage and checking if coverage less than 100%)
* upload coverage after it's collected
* added collecting of branch coverage