### PR TITLE
Fix pytest deprecation warnings

### DIFF
--- a/tests/test_schema_model_users.py
+++ b/tests/test_schema_model_users.py
@@ -8,7 +8,7 @@ def test_user_schema_dump_to_db_without_defaults():
         password="secret",
         is_superuser=False
     )
-    user_db = User(**user.dict(skip_defaults=True))  # type: ignore
+    user_db = User(**user.dict(exclude_unset=True))  # type: ignore
 
     assert user_db.email == "fake@example.com"
     assert user_db.password == "secret"

--- a/tests/test_schema_users.py
+++ b/tests/test_schema_users.py
@@ -10,7 +10,7 @@ def test_user_base():
     assert user.is_active
     assert not user.is_superuser
     assert not user.confirmed
-    assert user.dict(skip_defaults=True) == {'email': 'test@example.com'}
+    assert user.dict(exclude_unset=True) == {'email': 'test@example.com'}
     assert user.dict() == {
         'email': 'test@example.com', 'is_active': True,
         'is_superuser': False, 'confirmed': False
@@ -20,7 +20,7 @@ def test_user_base():
 def test_user_base_email_empty():
     user = UserBase()
     assert user.email is None
-    assert user.dict(skip_defaults=True) == {}
+    assert user.dict(exclude_unset=True) == {}
     assert user.dict() == {
         'email': None, 'is_active': True,
         'is_superuser': False, 'confirmed': False


### PR DESCRIPTION
* switch from `skip_defaults` parameter to `exclude_unset` when using pydantic `.dict()` method
* resolved `skip_defaults` deprecation warning